### PR TITLE
Remove destroy and edit actions from admin users

### DIFF
--- a/app/admin/admin_user.rb
+++ b/app/admin/admin_user.rb
@@ -1,6 +1,8 @@
 ActiveAdmin.register AdminUser do
   permit_params :email, :password, :password_confirmation
 
+  actions :all, except: [:destroy, :edit]
+
   index do
     selectable_column
     id_column


### PR DESCRIPTION
Until there are different roles for admin users, I'm disabling the edit/destroy actions on them so no one can wreak havoc. That means all changes need to be made from a console for now. 