### PR TITLE
Change id param to return next hash event instead of previous event

### DIFF
--- a/app/controllers/static_controller.rb
+++ b/app/controllers/static_controller.rb
@@ -5,7 +5,7 @@ class StaticController < ApplicationController
 
   def welcome
     if !params[:id] then
-      params[:id] = 0
+      params[:id] = 1
     end
     
     @next_hash = get_next_hash(params[:id].to_f)
@@ -25,7 +25,7 @@ class StaticController < ApplicationController
   def get_next_hash(id)
       url = CAL_URL + Time.zone.now.beginning_of_day.iso8601
       cal_results = open(url)
-      ev = JSON.parse(File.open(cal_results).read)["items"][0]
+      ev = JSON.parse(File.open(cal_results).read)["items"][id]
       Event.new ev
   rescue Exception => e
       puts e


### PR DESCRIPTION
This fixes the bug that displays the previous hash instead of the next hash on the home page. 