### PR TITLE
Move rego price to special event

### DIFF
--- a/app/controllers/event_registrations_controller.rb
+++ b/app/controllers/event_registrations_controller.rb
@@ -8,7 +8,7 @@ class EventRegistrationsController < ApplicationController
     rego = event.event_registrations.build
     if rego.update_attributes(update_params)
       return_url = "#{request.protocol}#{request.host_with_port}/paypal/success/#{event.url_code}";
-      redirect_to controller: "pay", action: "index", price: price, event_name: "#{event.url_code}", rego_id:"#{rego.id}", return_url: return_url 
+      redirect_to controller: "pay", action: "index", price: price, event_name: "#{event.url_code}", rego_id:"#{rego.id}", return_url: return_url
     else
       flash[:failure] = "Please fill out all required fields. Any field marked with * is required!"
       redirect_to new_special_event_event_registration_path(event)
@@ -30,7 +30,7 @@ class EventRegistrationsController < ApplicationController
   end
 
   def price
-    total = ordered_extra_hab? ? (EventRegistration.rego_price + EventRegistration::HAB_PRICE).to_s : EventRegistration.rego_price.to_s
+    total = ordered_extra_hab? ? (event.rego_price + EventRegistration::HAB_PRICE).to_s : event.rego_price.to_s
     total.to_f
   end
 

--- a/app/models/event_registration.rb
+++ b/app/models/event_registration.rb
@@ -2,27 +2,12 @@ class EventRegistration < ActiveRecord::Base
   FOOD_OPTIONS = ["Carnivore", "Vegetarian"]
   SHIRT_SIZES = ["S", "M", "L", "XL"]
   HAB_PRICE = 15
-  FIRST_TIER_DATE = Date.parse("2016-02-10")
-  SECOND_TIER_DATE = Date.parse("2016-04-01")
-  FIRST_TIER_PRICE = 69
-  SECOND_TIER_PRICE = 79
-  DEFAULT_PRICE = 89
 
   validates :contact_email, :hash_name, :nerd_name, :kennel, :payment_email, presence: true
 
   belongs_to :special_event
 
   after_initialize :set_defaults, if: :new_record?
-
-  def self.rego_price
-    if Date.current < FIRST_TIER_DATE
-      FIRST_TIER_PRICE
-    elsif Date.current < SECOND_TIER_DATE
-      SECOND_TIER_PRICE
-    else
-      DEFAULT_PRICE
-    end
-  end
 
   private
 

--- a/app/models/special_event.rb
+++ b/app/models/special_event.rb
@@ -5,4 +5,11 @@ class SpecialEvent < ActiveRecord::Base
   serialize :tiered_rego_dates, Array
 
   has_many :event_registrations
+
+  def rego_price
+    prices = tiered_rego_prices.sort
+    dates = tiered_rego_dates.sort
+
+    prices.find.with_index { |_,i| Date.current < dates[i] } || full_rego_price
+  end
 end

--- a/app/models/special_event.rb
+++ b/app/models/special_event.rb
@@ -1,8 +1,8 @@
 class SpecialEvent < ActiveRecord::Base
   validates :name, :date, :url_code, presence: true
 
-  serialize :tiered_rego_prices, Array
-  serialize :tiered_rego_dates, Array
+  serialize :tiered_rego_prices, JSON
+  serialize :tiered_rego_dates, JSON
 
   has_many :event_registrations
 

--- a/app/models/special_event.rb
+++ b/app/models/special_event.rb
@@ -1,5 +1,8 @@
 class SpecialEvent < ActiveRecord::Base
   validates :name, :date, :url_code, presence: true
 
+  serialize :tiered_rego_prices, Array
+  serialize :tiered_rego_dates, Array
+
   has_many :event_registrations
 end

--- a/app/models/special_event.rb
+++ b/app/models/special_event.rb
@@ -10,6 +10,6 @@ class SpecialEvent < ActiveRecord::Base
     prices = tiered_rego_prices.sort
     dates = tiered_rego_dates.sort
 
-    prices.find.with_index { |_,i| Date.current < dates[i] } || full_rego_price
+    prices.find.with_index { |_,i| Date.current <= dates[i] } || full_rego_price
   end
 end

--- a/app/models/special_event.rb
+++ b/app/models/special_event.rb
@@ -2,7 +2,7 @@ class SpecialEvent < ActiveRecord::Base
   validates :name, :date, :url_code, presence: true
 
   serialize :tiered_rego_prices, JSON
-  serialize :tiered_rego_dates, JSON
+  serialize :tiered_rego_dates
 
   has_many :event_registrations
 

--- a/db/migrate/20160218032228_add_tiered_rego_prices_to_special_events.rb
+++ b/db/migrate/20160218032228_add_tiered_rego_prices_to_special_events.rb
@@ -1,0 +1,5 @@
+class AddTieredRegoPricesToSpecialEvents < ActiveRecord::Migration
+  def change
+    add_column :special_events, :tiered_rego_prices, :text
+  end
+end

--- a/db/migrate/20160218032920_add_tiered_rego_dates_to_special_events.rb
+++ b/db/migrate/20160218032920_add_tiered_rego_dates_to_special_events.rb
@@ -1,0 +1,5 @@
+class AddTieredRegoDatesToSpecialEvents < ActiveRecord::Migration
+  def change
+    add_column :special_events, :tiered_rego_dates, :text
+  end
+end

--- a/db/migrate/20160218152631_add_full_rego_price_to_special_events.rb
+++ b/db/migrate/20160218152631_add_full_rego_price_to_special_events.rb
@@ -1,6 +1,5 @@
 class AddFullRegoPriceToSpecialEvents < ActiveRecord::Migration
   def change
     add_column :special_events, :full_rego_price, :float
-
   end
 end

--- a/db/migrate/20160218152631_add_full_rego_price_to_special_events.rb
+++ b/db/migrate/20160218152631_add_full_rego_price_to_special_events.rb
@@ -1,0 +1,6 @@
+class AddFullRegoPriceToSpecialEvents < ActiveRecord::Migration
+  def change
+    add_column :special_events, :full_rego_price, :float
+
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160108125643) do
+ActiveRecord::Schema.define(version: 20160218152631) do
 
   create_table "active_admin_comments", force: :cascade do |t|
     t.string   "namespace",     limit: 255
@@ -83,11 +83,14 @@ ActiveRecord::Schema.define(version: 20160108125643) do
   end
 
   create_table "special_events", force: :cascade do |t|
-    t.string   "name",       limit: 255
+    t.string   "name",               limit: 255
     t.date     "date"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "url_code",   limit: 255
+    t.string   "url_code",           limit: 255
+    t.text     "tiered_rego_prices"
+    t.text     "tiered_rego_dates"
+    t.float    "full_rego_price"
   end
 
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,2 +1,2 @@
 # Create the BH3 Marathon 2016 event
-SpecialEvent.create(name: "Boston H3 Marathon 2016: Dungeons and Drag Queens", date: Date.parse("2016-04-16"), url_code: "marathon_2016")
+SpecialEvent.create(name: "Boston H3 Marathon 2016: Dungeons and Drag Queens", date: Date.parse("2016-04-16"), url_code: "marathon_2016", tiered_rego_prices: [69, 79], tiered_rego_dates: [Date.parse("2016-02-09"), Date.parse("2016-03-31")], full_rego_price: 89)

--- a/spec/controllers/event_registrations_controller_spec.rb
+++ b/spec/controllers/event_registrations_controller_spec.rb
@@ -4,9 +4,7 @@ describe EventRegistrationsController do
   let(:event) { SpecialEvent.create(name: "Awesome Event", date: 1.month.from_now.to_date, url_code: "awesome_event") }
   let(:price) { 69.to_f }
 
-  before do
-    allow(EventRegistration).to receive(:rego_price).and_return(price)
-  end
+  before { allow_any_instance_of(SpecialEvent).to receive(:rego_price).and_return(price) }
 
   describe "#new" do
     before { get :new, special_event_id: event.id }

--- a/spec/models/event_registration_spec.rb
+++ b/spec/models/event_registration_spec.rb
@@ -17,32 +17,4 @@ describe EventRegistration do
     its(:registration_date) { should eq Date.current }
     its(:paid)              { should be false }
   end
-
-  describe ".rego_price" do
-    after { travel_back }
-
-    context "date is before first tier rego date" do
-      before { travel_to EventRegistration::FIRST_TIER_DATE - 1.day }
-
-      it "sets price at the first tier" do
-        expect(EventRegistration.rego_price).to eq EventRegistration::FIRST_TIER_PRICE
-      end
-    end
-
-    context "date is between first and second tier rego dates" do
-      before { travel_to EventRegistration::SECOND_TIER_DATE - 1.day }
-
-      it "sets the price at the second tier" do
-        expect(EventRegistration.rego_price).to eq EventRegistration::SECOND_TIER_PRICE
-      end
-    end
-
-    context "date is after second tier rego date" do
-      before { travel_to EventRegistration::SECOND_TIER_DATE + 1.day }
-
-      it "sets the price at the default tier" do
-        expect(EventRegistration.rego_price).to eq EventRegistration::DEFAULT_PRICE
-      end
-    end
-  end
 end

--- a/spec/models/event_registration_spec.rb
+++ b/spec/models/event_registration_spec.rb
@@ -1,5 +1,4 @@
 require "rails_helper"
-include ActiveSupport::Testing::TimeHelpers
 
 describe EventRegistration do
   it { should validate_presence_of :contact_email }

--- a/spec/models/special_event_spec.rb
+++ b/spec/models/special_event_spec.rb
@@ -49,5 +49,13 @@ describe SpecialEvent do
         expect(event.rego_price).to eq full_price
       end
     end
+
+    context "date is the first tiered date" do
+      before { travel_to earliest_date }
+
+      it "sets rego price at the first tier" do
+        expect(event.rego_price).to eq prices.first
+      end
+    end
   end
 end

--- a/spec/models/special_event_spec.rb
+++ b/spec/models/special_event_spec.rb
@@ -1,8 +1,53 @@
 require "rails_helper"
+include ActiveSupport::Testing::TimeHelpers
 
 describe SpecialEvent do
   it { should validate_presence_of :name }
   it { should validate_presence_of :date }
   it { should validate_presence_of :url_code }
   it { should have_many :event_registrations }
+
+  describe "#rego_price" do
+    subject(:event) { SpecialEvent.create(name: "Awesome Event", date: Date.parse("2016-05-01"), url_code: "awesome_event", tiered_rego_prices: prices, tiered_rego_dates: dates, full_rego_price: full_price) }
+    let(:full_price) { 99 }
+    let(:prices) { [69, 79, 89] }
+    let(:earliest_date) { Date.parse("2016-02-01") }
+    let(:middle_date) { Date.parse("2016-03-01") }
+    let(:latest_date) { Date.parse("2016-04-01") }
+    let(:dates) { [earliest_date, middle_date, latest_date] }
+
+    after { travel_back }
+
+    context "current date is before earliest tiered date" do
+      before { travel_to earliest_date - 1.day }
+
+      it "sets the first tier rego price" do
+        expect(event.rego_price).to eq prices.first
+      end
+    end
+
+    context "current date is between earliest and middle tiered date" do
+      before { travel_to middle_date - 1.day }
+
+      it "sets the first tier rego price" do
+        expect(event.rego_price).to eq prices[1]
+      end
+    end
+
+    context "current date is between earliest and middle tiered date" do
+      before { travel_to latest_date - 1.day }
+
+      it "sets the first tier rego price" do
+        expect(event.rego_price).to eq prices.last
+      end
+    end
+
+    context "date is after latest tiered date" do
+      before { travel_to latest_date + 1.day }
+
+      it "sets the full rego price" do
+        expect(event.rego_price).to eq full_price
+      end
+    end
+  end
 end


### PR DESCRIPTION
An event registration shouldn't have knowledge of the rego price for its event. Moving that logic into the special event model. 