### PR TITLE
Move registration attributes to event

### DIFF
--- a/app/controllers/event_registrations_controller.rb
+++ b/app/controllers/event_registrations_controller.rb
@@ -30,7 +30,7 @@ class EventRegistrationsController < ApplicationController
   end
 
   def price
-    total = ordered_extra_hab? ? (event.rego_price + EventRegistration::HAB_PRICE).to_s : event.rego_price.to_s
+    total = ordered_extra_hab? ? (event.rego_price + event.extra_hab_price).to_s : event.rego_price.to_s
     total.to_f
   end
 

--- a/app/models/event_registration.rb
+++ b/app/models/event_registration.rb
@@ -1,6 +1,4 @@
 class EventRegistration < ActiveRecord::Base
-  HAB_PRICE = 15
-
   validates :contact_email, :hash_name, :nerd_name, :kennel, :payment_email, presence: true
 
   belongs_to :special_event

--- a/app/models/event_registration.rb
+++ b/app/models/event_registration.rb
@@ -1,6 +1,4 @@
 class EventRegistration < ActiveRecord::Base
-  FOOD_OPTIONS = ["Carnivore", "Vegetarian"]
-  SHIRT_SIZES = ["S", "M", "L", "XL"]
   HAB_PRICE = 15
 
   validates :contact_email, :hash_name, :nerd_name, :kennel, :payment_email, presence: true

--- a/app/models/special_event.rb
+++ b/app/models/special_event.rb
@@ -1,4 +1,7 @@
 class SpecialEvent < ActiveRecord::Base
+  FOOD_OPTIONS = ["Carnivore", "Vegetarian"]
+  HAB_SIZES = ["S", "M", "L", "XL"]
+
   validates :name, :date, :url_code, presence: true
 
   serialize :tiered_rego_prices, JSON

--- a/app/views/event_registrations/new.html.haml
+++ b/app/views/event_registrations/new.html.haml
@@ -16,13 +16,14 @@
   = f.check_box :need_crash_space, {}, 1, 0
   = f.label "I need crash space!"
   %br
-  %span.extra-hab-checkbox
-    = f.check_box  :extra_hab, {}, "Shirt", nil
-  = f.label  "I want to purchase a marathon shirt for $15, which will be added to my rego price at checkout!"
-  %br
-  %span.extra-hab-size
-    = f.label  "Unisex Shirt Size"
-    = f.select :extra_hab_size, SpecialEvent::HAB_SIZES
+  - if @event.extra_hab_type
+    %span.extra-hab-checkbox
+      = f.check_box  :extra_hab, {}, "@event.extra_hab_type", nil
+    = f.label  "I want to purchase a marathon shirt for $15, which will be added to my rego price at checkout!"
+    %br
+    %span.extra-hab-size
+      = f.label  "#{@event.extra_hab_type} Size"
+      = f.select :extra_hab_size, SpecialEvent::HAB_SIZES
   %br
   %br
   %p You will be redirected to PayPal after registering to, you know, pay.

--- a/app/views/event_registrations/new.html.haml
+++ b/app/views/event_registrations/new.html.haml
@@ -8,7 +8,7 @@
   = f.input  :payment_email, label: "Payment Email (for PayPal)"
   = f.input  :kennel
   = f.label  :food_preference
-  = f.select :food_preference, EventRegistration::FOOD_OPTIONS
+  = f.select :food_preference, SpecialEvent::FOOD_OPTIONS
   %br
   = f.check_box :gluten_allergy, {}, 1, 0
   = f.label "I have a gluten allergy!"
@@ -22,7 +22,7 @@
   %br
   %span.extra-hab-size
     = f.label  "Unisex Shirt Size"
-    = f.select :extra_hab_size, EventRegistration::SHIRT_SIZES
+    = f.select :extra_hab_size, SpecialEvent::HAB_SIZES
   %br
   %br
   %p You will be redirected to PayPal after registering to, you know, pay.

--- a/db/migrate/20160218201753_add_extra_hab_type_and_price_to_special_events.rb
+++ b/db/migrate/20160218201753_add_extra_hab_type_and_price_to_special_events.rb
@@ -1,0 +1,6 @@
+class AddExtraHabTypeAndPriceToSpecialEvents < ActiveRecord::Migration
+  def change
+    add_column :special_events, :extra_hab_type, :string
+    add_column :special_events, :extra_hab_price, :float
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160218152631) do
+ActiveRecord::Schema.define(version: 20160218201753) do
 
   create_table "active_admin_comments", force: :cascade do |t|
     t.string   "namespace",     limit: 255
@@ -91,6 +91,8 @@ ActiveRecord::Schema.define(version: 20160218152631) do
     t.text     "tiered_rego_prices"
     t.text     "tiered_rego_dates"
     t.float    "full_rego_price"
+    t.string   "extra_hab_type"
+    t.float    "extra_hab_price"
   end
 
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,2 +1,2 @@
 # Create the BH3 Marathon 2016 event
-SpecialEvent.create(name: "Boston H3 Marathon 2016: Dungeons and Drag Queens", date: Date.parse("2016-04-16"), url_code: "marathon_2016", tiered_rego_prices: [69, 79], tiered_rego_dates: [Date.parse("2016-02-09"), Date.parse("2016-03-31")], full_rego_price: 89)
+SpecialEvent.create(name: "Boston H3 Marathon 2016: Dungeons and Drag Queens", date: Date.parse("2016-04-16"), url_code: "marathon_2016", tiered_rego_prices: [69, 79], tiered_rego_dates: [Date.parse("2016-02-09"), Date.parse("2016-03-31")], full_rego_price: 89, extra_hab_type: "Shirt", extra_hab_price: 15)

--- a/spec/controllers/event_registrations_controller_spec.rb
+++ b/spec/controllers/event_registrations_controller_spec.rb
@@ -1,8 +1,9 @@
 require "rails_helper"
 
 describe EventRegistrationsController do
-  let(:event) { SpecialEvent.create(name: "Awesome Event", date: 1.month.from_now.to_date, url_code: "awesome_event") }
+  let(:event) { SpecialEvent.create(name: "Awesome Event", date: 1.month.from_now.to_date, url_code: "awesome_event", extra_hab_type: "Shirt", extra_hab_price: hab_price) }
   let(:price) { 69.to_f }
+  let(:hab_price) { 15.to_f }
 
   before { allow_any_instance_of(SpecialEvent).to receive(:rego_price).and_return(price) }
 
@@ -38,6 +39,19 @@ describe EventRegistrationsController do
 
     it "redirects to PayPal" do
       expect(response).to redirect_to(controller: "pay", action: "index", price: price, event_name: event.url_code, rego_id: EventRegistration.first.id, return_url: "#{request.protocol}#{request.host_with_port}/paypal/success/#{event.url_code}")
+    end
+
+    context "the registration includes extra hab" do
+      let(:extra_hab) { "Shirt" }
+
+      it "adds extra hab to the event registration" do
+        expect(EventRegistration.first.extra_hab).to eq extra_hab
+        expect(EventRegistration.first.extra_hab_size).to eq extra_hab_size
+      end
+
+      it "adds the price of the hab to the rego price" do
+        expect(EventRegistration.first.rego_price).to eq(price + hab_price)
+      end
     end
 
     context "required registration information is missing" do


### PR DESCRIPTION
This moves the rest of the `SpecialEvent` attributes to that model and out of the `EventRegistration` model.