### PR TITLE
Fix hab bug in event registration view

### DIFF
--- a/app/views/event_registrations/new.html.haml
+++ b/app/views/event_registrations/new.html.haml
@@ -18,7 +18,7 @@
   %br
   - if @event.extra_hab_type
     %span.extra-hab-checkbox
-      = f.check_box  :extra_hab, {}, "@event.extra_hab_type", nil
+      = f.check_box  :extra_hab, {}, "#{@event.extra_hab_type}", nil
     = f.label  "I want to purchase a marathon shirt for $15, which will be added to my rego price at checkout!"
     %br
     %span.extra-hab-size


### PR DESCRIPTION
Found while deploying to the demo site, the `extra_hab` checkbox text wasn't being interpolated to show the type of hab being added to the order. 