### PR TITLE
Add Delete Rego button to admin view of event registrations

### DIFF
--- a/app/admin/event_registration.rb
+++ b/app/admin/event_registration.rb
@@ -1,11 +1,23 @@
 ActiveAdmin.register EventRegistration do
+  ACTIVE = 0
+
   permit_params :contact_email, :hash_name, :nerd_name, :kennel, :payment_email, :food_preference, :gluten_allergy, :need_crash_space, :extra_hab, :extra_hab_size, :registration_date, :paid
 
   actions :all, except: :destroy
 
+  action_item only: [:show, :edit] do
+    link_to "Delete Rego", delete_registration_path(id: params[:id]), method: :post
+  end
+
   SpecialEvent.all.order(date: :desc).each do |event|
     scope event.name.to_sym do |registrations|
       registrations.for_event(event)
+    end
+  end
+
+  controller do
+    def scoped_collection
+      super.where(status: ACTIVE)
     end
   end
 
@@ -40,6 +52,24 @@ ActiveAdmin.register EventRegistration do
     column :registration_date
     column :rego_price
     column :paid
+    column :status
     actions
+  end
+
+  form do |f|
+    f.inputs "Change the Fucking Event Regos Here, Hash Mothafuckas!" do
+      f.input :special_event
+      f.input :contact_email
+      f.input :hash_name
+      f.input :nerd_name
+      f.input :kennel
+      f.input :payment_email
+      f.input :food_preference
+      f.input :extra_hab
+      f.input :extra_hab_size
+      f.input :registration_date
+      f.input :rego_price
+    end
+    f.actions
   end
 end

--- a/app/controllers/event_registrations_controller.rb
+++ b/app/controllers/event_registrations_controller.rb
@@ -15,6 +15,11 @@ class EventRegistrationsController < ApplicationController
     end
   end
 
+  def delete
+    EventRegistration.find(params[:id]).deleted!
+    redirect_to mismanagement_event_registrations_path
+  end
+
   private
 
   def event

--- a/app/models/event_registration.rb
+++ b/app/models/event_registration.rb
@@ -1,6 +1,8 @@
 class EventRegistration < ActiveRecord::Base
   validates :contact_email, :hash_name, :nerd_name, :kennel, :payment_email, presence: true
 
+  enum status: [:active, :deleted]
+
   belongs_to :special_event
 
   after_initialize :set_defaults, if: :new_record?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,23 +8,23 @@ Bh3site::Application.routes.draw do
 
 # about routes
   get "/about" => "about#index"
-  get "about/history" 
-  get "about/mismanagement" 
-  
+  get "about/history"
+  get "about/mismanagement"
+
 # cal route
   get "calendar" => "static#calendar", as: :calendar
 
 #static route
   get "static/welcome/:id", to: "static#welcome"
   get "static/events"
-  
+
 #more route
   get "more" => "more#index"
   get "more/email" => "more#index"
   get "more/away" => "more#away"
   get "more/trail" => "more#trail"
-  get "more/habadashery" => "more#habadashery" 
-  
+  get "more/habadashery" => "more#habadashery"
+
 #posts route
   get "posts/:page_number" => "posts#index", as: :hashtrash
   get "posts/index/:page_number" => "posts#index"
@@ -43,7 +43,8 @@ end
   get "pay" => "pay#index"
   get "paypal/success/:url_code" => "pay#success"
 
-
+#event_registrations routes
+  post "event_registrations/:id/delete" => "event_registrations#delete", as: :delete_registration
   # The priority is based upon order of creation: first created -> highest priority.
   # See how all your routes lay out with "rake routes".
 
@@ -84,7 +85,7 @@ end
   #       get 'recent', on: :collection
   #     end
   #   end
-  
+
   # Example resource route with concerns:
   #   concern :toggleable do
   #     post 'toggle'

--- a/db/migrate/20170314215548_add_status_to_event_registrations.rb
+++ b/db/migrate/20170314215548_add_status_to_event_registrations.rb
@@ -1,0 +1,5 @@
+class AddStatusToEventRegistrations < ActiveRecord::Migration
+  def change
+    add_column :event_registrations, :status, :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160218201753) do
+ActiveRecord::Schema.define(version: 20170314215548) do
 
   create_table "active_admin_comments", force: :cascade do |t|
     t.string   "namespace"
@@ -63,6 +63,7 @@ ActiveRecord::Schema.define(version: 20160218201753) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.float    "rego_price"
+    t.integer  "status",            default: 0
   end
 
   create_table "hash_events", force: :cascade do |t|

--- a/spec/models/event_registration_spec.rb
+++ b/spec/models/event_registration_spec.rb
@@ -7,6 +7,7 @@ describe EventRegistration do
   it { should validate_presence_of :kennel }
   it { should validate_presence_of :payment_email }
   it { should belong_to :special_event }
+  it { should define_enum_for :status }
 
   describe "setting defaults upon creation" do
     subject(:rego) { EventRegistration.create(contact_email: "user@example.com", hash_name: "Test Hasher", nerd_name: "Nerd Name", kennel: "H3", payment_email: "user@example.com") }


### PR DESCRIPTION
NOTE: Using this button doesn't actually destroy the record, instead it changes the status of the record from `active` to `deleted`, ensuring that the data isn't truly lost. 

This PR also adds the status column to the EventRegistrations table as an enum. 